### PR TITLE
修正texlive2021下编译报错

### DIFF
--- a/NKThesis.sty
+++ b/NKThesis.sty
@@ -47,6 +47,7 @@
     \multiply\@tempcnta 256\relax
     \advance\@tempcnta#2\relax
     \char\@tempcnta}
+  \let\CJKaddEncHook\undefined
   \RequirePackage{CJKnumb}
   \csname xeCJK@enc@UTF8\endcsname
   \def\CJK@tenthousand{万}


### PR DESCRIPTION
修正在 TexLive2021 下编译时出现错误：LaTeX3 Error: Control sequence \CJKaddEncHook already defined.