### PR TITLE
处理xelatex下setmainfont有冲突的bug

### DIFF
--- a/NKTfonts.cfg
+++ b/NKTfonts.cfg
@@ -7,8 +7,8 @@
 
 \ifxetex
   \setmainfont{Times New Roman}
-  \setCJKmainfont[BoldFont={SimHei},ItalicFont={[simkai.ttf]}]{SimSun}
-  \setCJKmonofont{[simfang.ttf]}
+  \setCJKmainfont[BoldFont={SimHei},ItalicFont={KaiTi}]{SimSun}
+  \setCJKmonofont{FangSong}
 \else
   \ifpdf
     \pdfmapline{=gbksong@UGBK@ < stsong.ttf}

--- a/NKTfonts.cfg
+++ b/NKTfonts.cfg
@@ -6,9 +6,9 @@
 \ProvidesFile{NKTfonts.cfg}
 
 \ifxetex
+  \setmainfont{Times New Roman}
   \setCJKmainfont[BoldFont={SimHei},ItalicFont={[simkai.ttf]}]{SimSun}
   \setCJKmonofont{[simfang.ttf]}
-  \setmainfont{Times New Roman}
 \else
   \ifpdf
     \pdfmapline{=gbksong@UGBK@ < stsong.ttf}

--- a/NKThesis.sty
+++ b/NKThesis.sty
@@ -42,8 +42,9 @@
 \ifxetex
   \RequirePackage{xeCJK}
   \edef\CJK@UnicodeEnc{UTF8}
-  % TexLive2021/2022，xelatex编译时，需注释下行，以免报错LaTeX3 Error: Control sequence \CJKaddEncHook already defined.
+  \ifx\CJKaddEncHook#1#2\undefined
   \def\CJKaddEncHook#1#2{\expandafter\def\csname xeCJK@enc@#1\endcsname{#2}}
+  \fi
   \def\Unicode#1#2{\@tempcnta#1\relax
     \multiply\@tempcnta 256\relax
     \advance\@tempcnta#2\relax


### PR DESCRIPTION
修改setmainfont命令的位置，否则经测试，在windows和ubuntu下texlive2023 及 miktex 下，对times new roman字体的设置有冲突。