### PR TITLE
专业学位硕士打勾

### DIFF
--- a/NKThesis.cfg
+++ b/NKThesis.cfg
@@ -240,7 +240,8 @@
     \hss
     \NKT@au@item{博士}{boshi}\quad
     \NKT@au@item{学历硕士}{xuelishuoshi}\quad
-    \NKT@au@item{专业学位硕士}{shuoshizhuanyexuewei}\quad
+    %\NKT@au@item{专业学位硕士}{shuoshizhuanyexuewei}\quad
+    \NKT@au@item{专业学位硕士}{zhuanyexueweishuoshi}\quad
     %\NKT@au@item{高校教师}{gaoxiaojiaoshi}\quad
     \NKT@au@item{同等学力硕士}{tongdengxuelishuoshi}\quad  
   }

--- a/NKThesis.sty
+++ b/NKThesis.sty
@@ -627,7 +627,8 @@
 \csname CJK@makeInactive\endcsname
 \def\NKT@string@boshi{博士}
 \def\NKT@string@xuelishuoshi{学历硕士}
-\def\NKT@string@zhuanyeshuoshixuewei{硕士专业学位}
+%\def\NKT@string@zhuanyeshuoshixuewei{硕士专业学位}
+\def\NKT@string@zhuanyexueweishuoshi{专业学位硕士}
 \def\NKT@string@gaoxiaojiaoshi{高校教师}
 \def\NKT@string@tongdengxuelishuoshi{同等学力硕士}
 


### PR DESCRIPTION
论文类别中专业学位硕士无法打勾的解决办法：
这是由于NKThesis.cfg和NKThesis.sty文件中对专业学位硕士的设置不同。，更改如下：
NKThesis.cfg：第243行的{shuoshizhuanyexuewei}更改为{zhuanyexueweishuoshi}；
NKThesis.sty：第630行的zhuanyeshuoshixuewei{硕士专业学位}更改为zhuanyexueweishuoshi{专业学位硕士}。