### PR TITLE
部分格式修正（已在TeX Live 2018验证）

### DIFF
--- a/NKThesis.cfg
+++ b/NKThesis.cfg
@@ -1,6 +1,4 @@
 \tocdepth{3}
-\renewcommand*\l@section{\@dottedtocline{1}{1em}{3.5em}}
-\renewcommand*\l@subsection{\@dottedtocline{1}{2em}{2.5em}}
 \def\NKT@lunwenleibie{论文类别}
 \newcommand{\proof}[1][\NKT@proof]{\par\textbf{#1.}\,\, }
 \def\endproof{\hfill{\usefont{U}{msa}{m}{n}\char"03}}
@@ -80,7 +78,11 @@
      \ifx\NKT@key@lunwenleibie\NKT@string@boshi
        博士学位论文%
      \else
-       硕士学位论文%
+       \ifx\NKT@key@lunwenleibie\NKT@string@zhuanyexueweishuoshi
+        硕士专业学位论文%
+       \else
+        硕士学位论文%
+       \fi
      \fi}
 
   \vskip 15mm
@@ -95,7 +97,7 @@
   }
 
   \vskip 10mm
-  \zihaosi
+  \zihaoxiaosi
   \def\arraystretch{2}
   \tabcolsep 0.1em
   \begin{tabular}{lcl}

--- a/NKThesis.sty
+++ b/NKThesis.sty
@@ -321,8 +321,8 @@
   \tocsubsectiontitlewidth 60pt
 \else
   \tocchaptertitlewidth 42pt
-  \tocsectiontitlewidth 42pt
-  \tocsubsectiontitlewidth 60pt
+  \tocsectiontitlewidth 38pt
+  \tocsubsectiontitlewidth 38pt
 \fi
 
 \def\l@part#1#2{
@@ -352,8 +352,8 @@
     \advance\leftskip\toctitlesep
     \hskip -\leftskip
     \setnewwidth{#1}{#2}\nobreak\hfil\settowidth\npnumwidth{#3}%
-    \nobreak\leaders\hbox{\tocleaders}%
-    \hfill\nobreak\settowidth\npnumwidth{#3}%
+    \nobreak\hspace{.5em}\leaders\hbox{\tocleaders}%
+    \hfill\nobreak\hspace{.5em}\settowidth\npnumwidth{#3}%
     \hbox to\npnumwidth{\hfil #3}%
     \par
   \endgroup
@@ -589,10 +589,10 @@
 \def\tocchapterfonts{\rmfamily\zihaosi}
 \def\tocsectionfonts{\rmfamily\zihaoxiaosi}
 \def\tocsubsectionfonts{\rmfamily\zihaowu}
-\def\tocleaders{$\cdot\!\cdot\!\cdot\ $}
+\def\tocleaders{$\cdot$}
 \def\tocchapterindent{0em}
-\def\tocsectionindent{2em}
-\def\tocsubsectionindent{2em}
+\def\tocsectionindent{1em}
+\def\tocsubsectionindent{1em}
 \def\toctitlesep{12pt}
 \def\NKT@toc@over@part{12pt}
 \def\NKT@toc@below@part{6pt}

--- a/main.tex
+++ b/main.tex
@@ -27,6 +27,11 @@
 % 使用三级节标题，如1.2.3.4
 \setcounter{secnumdepth}{4}
 
+% 公式编号字体大小
+% \makeatletter 
+% \renewcommand\@eqnnum{{\zihaowu (\theequation)}} 
+% \makeatother
+
 \includeonly{
 	./tex/abstract,
 	./tex/introduction,

--- a/tex/references.tex
+++ b/tex/references.tex
@@ -2,12 +2,11 @@
 % -*- coding: utf-8 -*-
 
 {
-\zihaowu
+\def\bibfont{\fontsize{10.5}{16}\selectfont}
 \setlength{\bibitemsep}{0pt}
-\setstretch{1.3}
+\setlength{\parskip}{0pt}
 % 2020版标准4.8
 % 参考文献：标题要求同各章标题。文字部分：宋体10.5磅(或五号)，英文用Times New Roman字体10.5磅(或五号)，固定值行距16磅，段前段后0磅
-% TeXLive2021中xelatex编译，尝试直接设置行距固定值，似对printbibliography无效，因此使用了1.3 \approx 16 \div 12
 
 \printbibliography[title=参考文献]
 

--- a/tex/resume.tex
+++ b/tex/resume.tex
@@ -28,17 +28,31 @@ xxx，出生于yyyy年mm月dd日。
 
 % 注：这个要求似乎比参考文献宽松，因此没改。若强求格式，可改为普通文本并参照上一段修改字号行距等格式。
 
+{
+\zihaowu
+\setlength{\baselineskip}{16pt}
+\setlength{\parskip}{0pt}
+
 \begin{itemize}
 	\item 周恩来. 周恩来选集[M]. 人民出版社, 1980.
 	\item 周恩来. 周恩来外交文选[M]. 中央文献出版社, 1990.
 \end{itemize}
 
+}
 
 
 
 % 其他成果有可添加
 % \section*{\leftline{研究生期间其它成果:}}
 % % 研究成果可以是在学期间参加的研究项目、申请的专利或获奖等
+
+% {
+% \zihaowu
+% \setlength{\baselineskip}{16pt}
+% \setlength{\parskip}{0pt}
+
 % \begin{itemize}
 % 	\item 
 % \end{itemize}
+
+% }


### PR DESCRIPTION
参照2024版规范：
1. 题名页格式修改：
a. 专硕学位论文类型应为“硕士专业学位论文”（见规范2.2）
b. 论文作者、导师、申请学位、评阅人等信息字体大小应为小四（见规范4.4）

2. 目录格式修改（见规范4.6）：
a. 一级标题目录：宋体12磅(或小四)，单倍行距，段前6磅，段后0磅，两端对齐，页码右对齐，左缩进1个汉字符
b. 二级标题目录：宋体10.5磅(或五号),单倍行距，段前6磅，段后0磅，两端对齐，页码右对齐，左缩进2个汉字符

3. 参考文献（见规范4.8）：
标题要求同各章标题。文字部分：宋体10.5磅(或五号)，英文用Times New Roman字体10.5磅(或五号)，固定值行距16磅，段前段后0磅
原先的方法设置字体大小方式有误，并且实际显示的行间距并非16磅，所以换一种写法

4. 个人简历（见规范4.8）：
标题要求同各章标题。文字部分：宋体10.5磅(或五号)，英文用Times New Roman字体10.5磅(或五号)，固定值行距16磅，段前段后0磅，发表学术论文书写格式同参考文献
修改了发表论文和其他成果部分的字体大小

5. 表达式编号（见规范4.7）：
序号加圆括号，Times New Roman10.5磅(或五号)，右对齐
这个似乎不重要，所以加入的代码注释掉了，可酌情选择是否修改