### PR TITLE
优化题名页格式

### DIFF
--- a/NKThesis.cfg
+++ b/NKThesis.cfg
@@ -104,7 +104,7 @@
   \NKT@tp@itemv{论文作者}{lunwenzuozhe}  & \hbox to 5mm{} & \NKT@tp@itemv{指导教师}{zhidaojiaoshi}  \\
   \NKT@tp@itemv{申请学位}{shenqingxuewei}&                 & \NKT@tp@itemv{培养单位}{peiyangdanwei}  \\
   \NKT@tp@itemv{学科专业}{zhuanye}  &                 & \NKT@tp@itemv{研究方向}{yanjiufangxiang}\\
-  答辩委员会主席 \hskip 0.5em\underline{\hbox to 34mm{\hfil\NKT@keyvalue{dabianzhuxi}\hfil}} 
+  答辩委员会主席 \hskip 0.5em\underline{\hbox to 37.5mm{\hfil\NKT@keyvalue{dabianzhuxi}\hfil}} 
   &&\NKT@tp@itemv{评\hskip 0.5em 阅\hskip 0.5em人}{pingyueren}
 \end{tabular}
 


### PR DESCRIPTION
题名页中，将“答辩委员会主席”的下划线长度修改为和其他信息（例如导师、学科专业等信息）的平齐