### PR TITLE
修复问题 #50

### DIFF
--- a/NKThesis.sty
+++ b/NKThesis.sty
@@ -49,13 +49,13 @@
     \multiply\@tempcnta 256\relax
     \advance\@tempcnta#2\relax
     \char\@tempcnta}
-  \RequirePackage{CJKnumb}
+  \RequirePackage{zhnumber}
   \csname xeCJK@enc@UTF8\endcsname
   \def\CJK@tenthousand{万}
   \RequirePackage{graphicx}
   \RequirePackage[bookmarksnumbered]{hyperref}
 \else
-  \RequirePackage{CJK,CJKnumb}
+  \RequirePackage{CJK,zhnumber}
   \RequirePackage{uniGBK}
   \RequirePackage[unicode,bookmarksnumbered]{hyperref}
 %  \RequirePackage{CJKpunct}\RequirePackage{CJKspace}
@@ -114,8 +114,8 @@
   \def\figurename{Figure}
   \def\NKT@proof{Proof}
 \else
-  \def\chaptername{第\CJKnumber{\arabic{chapter}}章}
-  \def\thesection{第\CJKnumber{\arabic{section}}节}
+  \def\chaptername{第\zhnum{chapter}章}
+  \def\thesection{第\zhnum{section}节}
   \def\thesubsection{\arabic{chapter}.\arabic{section}.\arabic{subsection}}
   \def\contentsname{目录}
   \def\appendixnamenonumber{附录}


### PR DESCRIPTION
新版本latex中CJKnumb包存在兼容性错误，当CJKnumb和hyperref包共同使用时，无法正常转换标签中的中文数字，导致https://github.com/NewFuture/NKThesis/issues/50 生成的书签是”第1零章“。

此处仅需将CJKnumb更改为zhnumber包，并将\CJKnumber替换为\zhnum即可修复该问题。

我已在本地测试该修复有效。